### PR TITLE
Feature/insertar tarea

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,4 +35,4 @@ jobs:
       - name: Build and analyze
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=SebasMa24_Taller1 -Dsonar.sources=src/main/java,src/main/resources -Dsonar.plsql.database-dictionary=src/main/resources/db-dictionary.sql
+        run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=SebasMa24_Taller1 -Dsonar.sources=src/main/java,src/main/resources -Dsonar.plsql.database-dictionary=src/main/resources/db-dictionary.sql -Dsonar.coverage.exclusions=**/resources/static/**,**/resources/templates/**

--- a/docs/defects.csv
+++ b/docs/defects.csv
@@ -1,1 +1,4 @@
-id,pr,archivo,linea,tipo,severidad,descripcion,estado,reportado_por,decidido_por,comentarios
+id,pr,archivo,linea,tipo,severidad,descripcion,estado,reportado_por
+DEF-001,6,TareaService.java,51,Funcionalidad,Alta,"Permite crear/actualizar una tarea con un ID existente, sobrescribiendo datos.",Pendiente,MiguelVeloza
+DEF-002,6,index.html,26,UI/Visual,Baja,"El texto de tareas largas se desborda del contenedor, afectando la visualización.",Aceptado,MiguelVeloza
+DEF-003,6,TareaController.java,45,Configuración,Media,"El endpoint para crear tareas está en la raíz / en lugar de /tareas, lo que puede generar conflictos.",Pendiente,MiguelVeloza

--- a/docs/enlaces.md
+++ b/docs/enlaces.md
@@ -25,7 +25,7 @@ Este documento recopila los enlaces principales del taller 1, incluyendo Issues,
 
 | ID    | Rama                     | Enlace PR                                          | Estado    |
 |-------|---------------------     |----------------------------------------------------|-----------|
-| HU-01 | feature/01-insertar      | [PR #](https://github.com/SebasMa24/Taller1/pulls) | No Subido |
+| HU-01 | feature/01-insertar      | [PR #6](https://github.com/SebasMa24/Taller1/pull/6) | Mergeado |
 | HU-02 | feature/02-estado_tarea  | [PR #](https://github.com/SebasMa24/Taller1/pulls) | No Subido |
 | HU-03 | feature/03-editar        | [PR #](https://github.com/SebasMa24/Taller1/pulls) | No Subido |
 | HU-04 | feature/03-eliminar      | [PR #](https://github.com/SebasMa24/Taller1/pulls) | No Subido |

--- a/docs/reviews/PR-checklist 6-2.md
+++ b/docs/reviews/PR-checklist 6-2.md
@@ -1,0 +1,54 @@
+# Checklist de Revisión de Código - PR #<#>
+
+**Título del PR: Feature/insertar tarea**  
+**Autor/a:Luis Sebastian Martinez Guerrero**  
+**Revisores/as:Miguel Angel Veloza y Yahir Camilo Forero Santos**  
+**Fecha de revisión:25/09/2025**  
+
+---
+
+## 1. Criterios de Aceptación
+
+- [x] Se cumple el flujo principal de la historia de usuario.
+- [x] Se manejan casos borde (entrada vacía, no encontrada, errores).
+- [x] La funcionalidad cumple con la definición de “Hecho” (DoD).
+
+## 2. Legibilidad y Mantenibilidad
+
+- [x] Nombres de variables y funciones claros y consistentes.
+- [x] Funciones concisas y bien estructuradas.
+- [x] Comentarios solo donde agreguen valor.
+- [x] Código modular organizado correctamente (`src/`).
+
+## 3. Evidencias y Pruebas
+
+- [x] Incluye al menos una prueba ejecutable en `/tests`.
+- [?] Evidencia adjunta (captura o video en la descripción del PR).
+- [x] Todas las pruebas pasan correctamente.
+
+> Observaciones:  
+> Se ejecutaron correctamente las pruebas automaticas
+> Dado que se uso analizador de codigo estatico no se requiere evidencia adjunta.
+
+## 4. GitHub Actions
+
+- [x] Workflow de `Static Analysis` ejecutado correctamente.
+- [x] El PR muestra el check en verde antes del merge.
+
+## 5. Resumen y Decisión
+
+**Estado final del PR:**  
+
+- [x] Mergeado  
+- [ ] Cambios solicitados  
+
+**Comentarios finales:**
+> Listo para hacer merge
+
+## 6. Defectos detectados
+
+| ID       | Archivo        | Línea | Tipo       | Severidad | Estado    |
+|----------|----------------|-------|------------|-----------|-----------|
+| |   |  |    |  |  |
+
+> Detalle completo en `docs/defects.csv`

--- a/docs/reviews/PR-checklist-feature-insertar-tarea-1.md
+++ b/docs/reviews/PR-checklist-feature-insertar-tarea-1.md
@@ -1,0 +1,62 @@
+# Checklist de Revisión de Código - PR #<6>
+
+**Título del PR: Feature/insertar tarea**  
+**Autor/a: Luis Sebastian Martinez Guerrero **  
+**Revisores/as: Miguel Angel Veloza y Yahir Camilo Forero Santos**  
+**Fecha de revisión:25/09/2025**  
+
+---
+
+### 1. Criterios de aceptacion
+
+* [X] Agregar tarea con título válido y verla en la lista al recargar.
+* [X] Se valida que el título **no sea vacío**.
+* [X] Se valida que el título **no exceda 100 caracteres** y de un mensaje de advertencia.
+* [X] Persistencia de tarea después de recarga
+* [ ] El endpoint en `TareaController` es `POST /tareas` (correcto en REST).
+
+
+### 2. Pruebas unitarias
+
+* [X] Existe al menos un test para título vacío → falla con BAD_REQUEST.
+* [X] Existe al menos un test para crear tarea
+* [X] Existe al menos un test para título null → falla con BAD_REQUEST.
+* [X] Existe al menos un test para título >100 caracteres → falla con BAD_REQUEST.
+
+### 3. Casos borde adicionales
+
+* [X] ¿Qué pasa si el título tiene exactamente 100 caracteres? (debería ser válido).
+* [X] ¿Qué pasa si se envían campos adicionales en el JSON? (no debería romper el flujo).
+* [X] ¿Qué pasa si no se envía `title` en el JSON? (probablemente BAD_REQUEST).
+* [ ] ¿Qué pasa so se envia una nota con el mismo id?  -> Lo permite y se actualiza
+ 
+### 4. GitHub Actions
+
+- [X] Workflow de `Static Analysis` ejecutado correctamente.
+- [X] El PR muestra el check en verde antes del merge.
+
+> Observaciones:  
+> Se ejecutaron correctamente las pruebas automaticas
+
+## 5. Resumen y Decisión
+
+**Estado final del PR:**  
+
+- [ ] Mergeado  
+- [x] Cambios solicitados  
+
+**Comentarios finales:**
+> - Actualmente se permite crear una tarea con un ID existente, lo que provoca que la tarea anterior se sobrescriba. Esto podría generar pérdida de datos.
+> - Nota de visualización: Cuando el título de la tarea excede el límite del contenedor, el texto se desborda y afecta la presentación.
+Sugerencia: Limitar la longitud visible con CSS (text-overflow: ellipsis;) o ajustar el tamaño del contenedor para mantener la UI consistente.
+> - El endpoint para crear tareas está en la raíz (/), lo que puede causar conflictos con otros endpoints de la aplicación.
+Sugerencia: Considerar agregar un path base en el Controller, por ejemplo @PostMapping("/tareas"), para que el endpoint sea /tareas y mantener consistencia en la API.
+
+## 6. Defectos detectados
+| id       | pr | archivo           | linea | tipo            | severidad   | descripcion                                                                 | estado        | reportado_por   |
+|----------|----|-----------------|-------|----------------|------------|-----------------------------------------------------------------------------|---------------|----------------|
+| DEF-001  | 6  | TareaService.java | 51   | Funcionalidad  | Alta       | Permite crear/actualizar una tarea con un ID existente, sobrescribiendo datos.| Pendiente       | MiguelVeloza   |
+| DEF-002  | 6  | index.html | 26   | UI/Visual      | Baja       | El texto de tareas largas se desborda del contenedor, afectando la visualización.| Aceptado       | MiguelVeloza   |
+| DEF-003  | 6  | TareaController.java | 45   | Configuración  | Media      | El endpoint para crear tareas está en la raíz `/` en lugar de `/tareas`, lo que puede generar conflictos.| Pendiente      | MiguelVeloza   |
+
+> Detalle completo en `docs/defects.csv`

--- a/src/main/java/com/Taller1/Taller1/Controller/TareaController.java
+++ b/src/main/java/com/Taller1/Taller1/Controller/TareaController.java
@@ -2,9 +2,13 @@ package com.Taller1.Taller1.Controller;
 
 import java.util.List;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import com.Taller1.Taller1.Entity.Tarea;
@@ -34,8 +38,14 @@ public class TareaController {
         }
 
         model.addAttribute("tareas", tareas);
+        model.addAttribute("tareaNueva", new Tarea());
         return "index";
     }
 
+    @PostMapping
+    public ResponseEntity<?> crearTarea(@RequestBody Tarea tareaNueva) {
+        Tarea creada = tareaService.crearTarea(tareaNueva);
+        return ResponseEntity.status(HttpStatus.CREATED).body(creada);
+    }
     
 }

--- a/src/main/java/com/Taller1/Taller1/Controller/TareaController.java
+++ b/src/main/java/com/Taller1/Taller1/Controller/TareaController.java
@@ -42,7 +42,7 @@ public class TareaController {
         return "index";
     }
 
-    @PostMapping
+    @PostMapping("/tarea")
     public ResponseEntity<?> crearTarea(@RequestBody Tarea tareaNueva) {
         Tarea creada = tareaService.crearTarea(tareaNueva);
         return ResponseEntity.status(HttpStatus.CREATED).body(creada);

--- a/src/main/java/com/Taller1/Taller1/Service/TareaService.java
+++ b/src/main/java/com/Taller1/Taller1/Service/TareaService.java
@@ -49,6 +49,9 @@ public class TareaService {
 
     // Crear una nueva tarea
     public Tarea crearTarea(Tarea tarea) {
+        if (tareaRepository.existsById(tarea.getId())) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "La tarea con ID " + tarea.getId() + " ya existe");
+        }
         if (tarea.getTitulo() == null || tarea.getTitulo().isEmpty()) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "El título de la tarea no puede estar vacío");
         }

--- a/src/main/java/com/Taller1/Taller1/Service/TareaService.java
+++ b/src/main/java/com/Taller1/Taller1/Service/TareaService.java
@@ -5,7 +5,9 @@ import java.time.temporal.IsoFields;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 
 import com.Taller1.Taller1.Entity.Tarea;
 import com.Taller1.Taller1.Repository.TareaRepository;
@@ -43,5 +45,17 @@ public class TareaService {
                 .filter(t -> t.getFechaVencimiento() != null &&
                         t.getFechaVencimiento().get(IsoFields.WEEK_OF_WEEK_BASED_YEAR) == numeroSemana)
                 .toList();
+    }
+
+    // Crear una nueva tarea
+    public Tarea crearTarea(Tarea tarea) {
+        if (tarea.getTitulo() == null || tarea.getTitulo().isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "El título de la tarea no puede estar vacío");
+        }
+        if (tarea.getTitulo().length() > 100) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "El título de la tarea no puede exceder 100 caracteres");
+        }
+        tarea.setEstado("PENDIENTE");
+        return tareaRepository.save(tarea);
     }
 }

--- a/src/main/resources/static/script.js
+++ b/src/main/resources/static/script.js
@@ -55,3 +55,16 @@ function mostrarMensaje(mensaje, tipo = 'error', tiempo = tipo === 'error' ? 500
 function obtenerDatosFormulario(formElement) {
     return Object.fromEntries(new FormData(formElement));
 }
+
+document.getElementById("form-tarea").addEventListener("submit", async function (e) {
+    e.preventDefault();
+
+    try {
+        const datosFormulario = obtenerDatosFormulario(e.target);
+        await fetchWithErrorHandling("/", "POST", datosFormulario);
+        e.target.reset();
+        mostrarMensaje("Tarea creada exitosamente!", "success");
+    } catch (error) {
+        mostrarMensaje(error.message);
+    }
+});

--- a/src/main/resources/static/script.js
+++ b/src/main/resources/static/script.js
@@ -61,7 +61,7 @@ document.getElementById("form-tarea").addEventListener("submit", async function 
 
     try {
         const datosFormulario = obtenerDatosFormulario(e.target);
-        await fetchWithErrorHandling("/", "POST", datosFormulario);
+        await fetchWithErrorHandling("/tarea", "POST", datosFormulario);
         e.target.reset();
         mostrarMensaje("Tarea creada exitosamente!", "success");
     } catch (error) {

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -23,6 +23,30 @@
     <!-- Popup de error -->
     <div id="error-popup" class="hidden fixed top-4 right-4 bg-red-500 text-black px-4 py-2 rounded shadow-lg"></div>
 
+    <!-- Formulario para agregar tarea -->
+    <section class="bg-white rounded-lg shadow-md p-6 mb-6">
+      <h2 class="text-xl font-semibold mb-4">Agregar Nueva Tarea</h2>
+      <form id="form-tarea" th:object="${tareaNueva}" class="space-y-4">
+        <div>
+          <label for="titulo" class="block text-gray-700 font-medium mb-1">Título</label>
+          <input type="text" id="titulo" name="titulo" th:field="*{titulo}" placeholder="Título de la tarea"
+            class="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400" required/>
+        </div>
+        <div>
+          <label for="descripcion" class="block text-gray-700 font-medium mb-1">Descripción</label>
+          <textarea id="descripcion" name="descripcion" th:field="*{descripcion}" placeholder="Descripción de la tarea"
+            class="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400"></textarea>
+        </div>
+        <div>
+          <label for="fechaVencimiento" class="block text-gray-700 font-medium mb-1">Fecha de Vencimiento</label>
+          <input type="date" id="fechaVencimiento" name="fechaVencimiento" th:field="*{fechaVencimiento}"
+            class="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400" required/>
+        <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 transition">
+          Agregar tarea
+        </button>
+      </form>
+    </section>
+    
     <!-- Listado de tareas -->
     <section class="bg-white rounded-lg shadow-md p-6">
       <h2 class="text-xl font-semibold mb-4">Lista de Tareas</h2>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -30,7 +30,7 @@
         <div>
           <label for="titulo" class="block text-gray-700 font-medium mb-1">Título</label>
           <input type="text" id="titulo" name="titulo" th:field="*{titulo}" placeholder="Título de la tarea"
-            class="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400" required/>
+            class="w-full text-ellipsis border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400" required/>
         </div>
         <div>
           <label for="descripcion" class="block text-gray-700 font-medium mb-1">Descripción</label>

--- a/src/test/java/com/Taller1/Taller1/TareaServiceTest.java
+++ b/src/test/java/com/Taller1/Taller1/TareaServiceTest.java
@@ -52,6 +52,18 @@ class TareaServiceTest {
     }
 
     @Test
+    void crearTarea_conIdExistente_debeLanzarExcepcion() {
+        when(tareaRepository.existsById(tarea.getId())).thenReturn(true);
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> {
+            tareaService.crearTarea(tarea);
+        });
+
+        assertEquals("La tarea con ID " + tarea.getId() + " ya existe", exception.getReason());
+        verify(tareaRepository, never()).save(any());
+    }
+
+    @Test
     void crearTarea_conTituloVacio_debeLanzarExcepcion() {
         tarea.setTitulo("");
 

--- a/src/test/java/com/Taller1/Taller1/TareaServiceTest.java
+++ b/src/test/java/com/Taller1/Taller1/TareaServiceTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDate;
 import java.util.Arrays;
@@ -16,6 +17,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 class TareaServiceTest {
@@ -26,9 +28,96 @@ class TareaServiceTest {
     @InjectMocks
     private TareaService tareaService;
 
+    private Tarea tarea;
+
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
+        tarea = new Tarea();
+        tarea.setId(1L);
+        tarea.setTitulo("Tarea de prueba");
+        tarea.setDescripcion("Descripción de prueba");
+        tarea.setEstado("PENDIENTE");
+    }
+
+    @Test
+    void crearTarea_conTituloValido_debeGuardarTarea() {
+        when(tareaRepository.save(any(Tarea.class))).thenReturn(tarea);
+
+        Tarea resultado = tareaService.crearTarea(tarea);
+
+        assertNotNull(resultado);
+        assertEquals("Tarea de prueba", resultado.getTitulo());
+        verify(tareaRepository, times(1)).save(tarea);
+    }
+
+    @Test
+    void crearTarea_conTituloVacio_debeLanzarExcepcion() {
+        tarea.setTitulo("");
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> {
+            tareaService.crearTarea(tarea);
+        });
+
+        assertEquals("El título de la tarea no puede estar vacío", exception.getReason());
+        verify(tareaRepository, never()).save(any());
+    }
+
+    @Test
+    void crearTarea_conTituloNull_debeLanzarExcepcion() {
+        tarea.setTitulo(null);
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> {
+            tareaService.crearTarea(tarea);
+        });
+
+        assertEquals("El título de la tarea no puede estar vacío", exception.getReason());
+    }
+
+    @Test
+    void crearTarea_conTituloMuyLargo_debeLanzarExcepcion() {
+        tarea.setTitulo("A".repeat(101));
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> {
+            tareaService.crearTarea(tarea);
+        });
+
+        assertEquals("El título de la tarea no puede exceder 100 caracteres", exception.getReason());
+    }
+
+    @Test
+    void crearTarea_conTituloEnLimite_debeGuardarCorrectamente() {
+        tarea.setTitulo("A".repeat(100));
+        when(tareaRepository.save(any(Tarea.class))).thenReturn(tarea);
+
+        Tarea resultado = tareaService.crearTarea(tarea);
+
+        assertNotNull(resultado);
+        assertEquals(100, resultado.getTitulo().length());
+        verify(tareaRepository, times(1)).save(tarea);
+    }
+
+    @Test
+    void crearTarea_conDescripcionNull_debeGuardarCorrectamente() {
+        tarea.setDescripcion(null);
+        when(tareaRepository.save(any(Tarea.class))).thenReturn(tarea);
+
+        Tarea resultado = tareaService.crearTarea(tarea);
+
+        assertNotNull(resultado);
+        assertNull(resultado.getDescripcion());
+    }
+
+    @Test
+    void crearTarea_conFechaVencimiento_debeGuardarCorrectamente() {
+        LocalDate fecha = LocalDate.now().plusDays(5);
+        tarea.setFechaVencimiento(fecha);
+        when(tareaRepository.save(any(Tarea.class))).thenReturn(tarea);
+
+        Tarea resultado = tareaService.crearTarea(tarea);
+
+        assertNotNull(resultado);
+        assertEquals(fecha, resultado.getFechaVencimiento());
     }
 
     @Test


### PR DESCRIPTION
### Descripción general de la Pull Request: `feature/insertar_tarea`

Esta rama implementa la funcionalidad de **creación de tareas** en la aplicación, incluyendo las validaciones de negocio y las pruebas unitarias correspondientes. Los cambios principales incluyen:

1. **Implementación de la creación de tareas:**

   * Se añadió el método `crearTarea` en `TareaService` para manejar la lógica de negocio.
   * Se incluyeron validaciones:

     * El título no puede ser vacío (`null` o cadena vacía).
     * El título no puede exceder 100 caracteres.

2. **Controlador `TareaController`:**

   * Se agregó el endpoint correspondiente para crear tareas (`POST /tareas`).
   * El Controller delega las validaciones de negocio al Service y permite que las excepciones `ResponseStatusException` se propaguen, garantizando respuestas con el estado HTTP adecuado.

3. **Pruebas unitarias:**

   * Se añadieron pruebas unitarias en `TareaControllerTest` para validar los casos de error más relevantes:

     * Crear tarea con título vacío → devuelve `BAD_REQUEST`.
     * Crear tarea con título `null` → devuelve `BAD_REQUEST`.
     * Crear tarea con título demasiado largo (>100 caracteres) → devuelve `BAD_REQUEST`.
   * Las pruebas usan `assertThrows` para verificar que el Controller propaga correctamente las excepciones lanzadas por el Service.